### PR TITLE
Fix `frontend` deployment name in command in getting started tutorial

### DIFF
--- a/input/start/index.md
+++ b/input/start/index.md
@@ -305,7 +305,7 @@ the frontend accessible using a conventional Kubernetes ingress.
 
 <div class="code-label session-2">West</div>
 
-    kubectl expose deployment hello-world-frontend --port 8080 --type LoadBalancer
+    kubectl expose deployment frontend --port 8080 --type LoadBalancer
 
 It takes a moment for the external IP to become available.
 


### PR DESCRIPTION
I was following https://skupper.io/start/index.html and the command I was given there did not work

```
$ kubectl expose deployment hello-world-frontend --port 8080 --type LoadBalancer
Error from server (NotFound): deployments.apps "hello-world-frontend" not found
```

I had to make the change to

```
$ kubectl expose deployment frontend --port 8080 --type LoadBalancer
service/frontend exposed
```