### PR TITLE
generate cli reference pages

### DIFF
--- a/man.sh
+++ b/man.sh
@@ -1,0 +1,4 @@
+rm -r input/docs/k8s-cli
+skupper man
+mv docs.out input/docs/k8s-cli
+python reference.py input/docs/k8s-cli

--- a/reference.py
+++ b/reference.py
@@ -1,0 +1,41 @@
+import os
+import argparse
+import re
+
+def add_yaml_header_and_replace_md(file_path, title):
+    """
+    Add YAML header to the file and replace '.md' with '.html'.
+    """
+    with open(file_path, 'r+') as file:
+        content = file.read()
+        content = content.replace('.md', '.html')
+        file.seek(0, 0)
+        file.write('---\n')
+        file.write(f'title: {title}\n')
+        file.write('---\n')
+        file.write(content)
+
+def process_directory(path):
+    """
+    Process each markdown file in the given directory.
+    """
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if file.endswith('.md'):
+                file_path = os.path.join(root, file)
+                parent_dir = os.path.basename(os.path.dirname(file_path))
+                title = f"{parent_dir}: {file}"
+                title = title.replace('.md', '')
+                title = title.replace('_', ' ')
+                
+                add_yaml_header_and_replace_md(file_path, title)
+
+def main():
+    parser = argparse.ArgumentParser(description="Process markdown files in a specified directory.")
+    parser.add_argument("path", type=str, help="Path to the directory containing markdown files")
+    args = parser.parse_args()
+
+    process_directory(args.path)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
With antora gone, we need something like this to publish the cli reference pages.
Currently we publish to:

/docs/cli-reference/skupper.html
/docs/cli-podman/skupper.html

This PR changes the urls to 
/docs/k8s-cli
/docs/pod-cli

Also, the source md files are generated in this repo and edited to make links work and to add yaml for breadcrumb:

![image](https://github.com/skupperproject/skupper-website/assets/5154224/e0bac9fc-81eb-46ff-9180-804335b3cbe9)
