### PR TITLE
fix table and {{.ID}} rendering

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -10,6 +10,3 @@ _latest_release = read_json("input/data/releases.json")["latest"]
 
 latest_release_version = _latest_release["version"]
 latest_release_date = format_date(parse_timestamp(_latest_release["date"]))
-ID = "{{.ID}}"
-Image="{{.Image}}"
-Labels="{{.Labels}}"

--- a/convert-all.sh
+++ b/convert-all.sh
@@ -21,8 +21,11 @@ cp -r subrepos/skupper-docs/images/ input/docs/
 # To process nested numbered lists
 python python/nested-numbers.py input/docs/operator/
 
-# To workaround https://github.com/ssorj/plano/issues/3
+# To workaround transform interpreting {{.ID}} as a var:
 
-sed -i 's/.ID/ID/g' input/docs/cli/podman.md
-sed -i 's/.Image/Image/g' input/docs/cli/podman.md
-sed -i 's/.Labels/Labels/g' input/docs/cli/podman.md
+sed -i 's/.ID/{.ID}/g' input/docs/cli/podman.md
+sed -i 's/.Image/{.Image}/g' input/docs/cli/podman.md
+sed -i 's/.Labels/{.Labels}/g' input/docs/cli/podman.md
+
+# To workaround https://github.com/skupperproject/skupper-website/issues/81
+sed -i 's/   | /| /g' input/docs/kubernetes/deployment-concerns.md

--- a/docs/docs/cli/native-security-options.html
+++ b/docs/docs/cli/native-security-options.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <title>Skupper - #Securing a service network</title>
+    <title>Skupper - # Securing a service network</title>
     <meta name="description" content="Multicluster communication for Kubernetes.  Skupper is a layer 7 service interconnect.  It enables secure communication across Kubernetes clusters with no VPNs or special firewall rules."/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,300italic,400,400italic,700,700italic|Roboto+Mono:400,400italic|Alegreya+Sans:300,300italic,400,400italic,500,500italic,700,700italic;display=optional"/>
@@ -58,7 +58,7 @@
       </div>
     </div>
   </nav>
-  <nav id="-path-nav"><div><a href="/docs/index.html">Documentation</a> <span class="path-separator">&#8250;</span> <a href="/docs/cli/index.html">Using the Skupper CLI</a> <span class="path-separator">&#8250;</span> <a href="/docs/cli/native-security-options.html">#Securing a service network</a></div></nav>
+  <nav id="-path-nav"><div><a href="/docs/index.html">Documentation</a> <span class="path-separator">&#8250;</span> <a href="/docs/cli/index.html">Using the Skupper CLI</a> <span class="path-separator">&#8250;</span> <a href="/docs/cli/native-security-options.html"># Securing a service network</a></div></nav>
   <nav id="-site-menu-layer" style="display: none;">
     <div>
       <a href="/index.html">Home</a>

--- a/docs/docs/kubernetes/deployment-concerns.html
+++ b/docs/docs/kubernetes/deployment-concerns.html
@@ -91,12 +91,31 @@ Increasing the number of routers does not improve network performance.  An incom
 <li><p>Determine the router CPU allocation you require.</p>
 <p>By default, the router CPU allocation is <code>BestEffort</code> as described in <a href="https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#besteffort">Pod Quality of Service Classes</a>.</p>
 <p>Consider the following CPU allocation options:</p>
-<p>| Router CPU | Description |
-| --- | --- |
-| 1 | Helps avoid issues with <code>BestEffort</code> on low resource clusters |
-| 2 | Suitable for production environments |
-| 5 | Maximum performance |</p>
 </li>
+</ol>
+<table>
+<thead>
+<tr>
+  <th>Router CPU</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>1</td>
+  <td>Helps avoid issues with <code>BestEffort</code> on low resource clusters</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>Suitable for production environments</td>
+</tr>
+<tr>
+  <td>5</td>
+  <td>Maximum performance</td>
+</tr>
+</tbody>
+</table>
+<ol start="2">
 <li><p>If you are using the Skupper CLI, set the CPU allocation for the router using the <code>--router-cpu</code> option.  For example:</p>
 <pre><code class="language-bash">$ skupper init --router-cpu 2
 </code></pre>

--- a/input/docs/cli/podman.md
+++ b/input/docs/cli/podman.md
@@ -337,7 +337,7 @@ This procedure removes all containers, volumes and networks labeled `application
 To check the labels associated with running containers:
 
 ```bash
-$ podman ps -a --format "{{ID}}  {{Image}}  {{Labels}}"
+$ podman ps -a --format "{{{.ID}}}  {{{.Image}}}  {{{.Labels}}}"
 ```
 </dd></dl>
 

--- a/input/docs/kubernetes/deployment-concerns.md
+++ b/input/docs/kubernetes/deployment-concerns.md
@@ -23,11 +23,11 @@ Increasing the number of routers does not improve network performance.  An incom
 
    Consider the following CPU allocation options:
 
-   | Router CPU | Description |
-   | --- | --- |
-   | 1 | Helps avoid issues with `BestEffort` on low resource clusters |
-   | 2 | Suitable for production environments |
-   | 5 | Maximum performance |
+| Router CPU | Description |
+| --- | --- |
+| 1 | Helps avoid issues with `BestEffort` on low resource clusters |
+| 2 | Suitable for production environments |
+| 5 | Maximum performance |
 2. If you are using the Skupper CLI, set the CPU allocation for the router using the `--router-cpu` option.  For example:
 
    ```bash


### PR DESCRIPTION
Add sed to process indented tables  https://github.com/skupperproject/skupper-website/issues/81
Remove var definitions from config.py, and use sed to add extra curly brackets
